### PR TITLE
fix port configuration for app container

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@
 
 # wait for all services to start-up
 if [ "$1" = '--wait-for-dependencies' ]; then
-    sh -c "while ! nc -w 1 -z $APP_PORT_80_TCP_ADDR $APP_PORT_80_TCP_PORT; do echo 'Waiting for app...'; sleep 2; done"
+    sh -c "while ! nc -w 1 -z $APP_PORT_5000_TCP_ADDR $APP_PORT_5000_TCP_PORT; do echo 'Waiting for app...'; sleep 2; done"
     echo "app is up"
     sh -c "while ! nc -w 1 -z $PYCSW_PORT_80_TCP_ADDR $PYCSW_PORT_80_TCP_PORT; do echo 'Waiting for pycsw...'; sleep 2; done"
     echo "pycsw is up"

--- a/nginx.conf
+++ b/nginx.conf
@@ -35,7 +35,7 @@ http {
             proxy_set_header X-Real-IP  $remote_addr;
             proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header Host $host;
-            proxy_pass http://app;
+            proxy_pass http://app:5000;
         }
 
         location = /csw-all {


### PR DESCRIPTION
This container was getting stuck in a loop `Waitin for app..` because it was looking for a connection to the app container on port 80. However the app container runs on port 5000.  After fixing the entrypoint script, nginx was failing to handle requests because they were being proxied to the app container on port 80 instead of port 5000.  I tested by rebuilding this container and then making a curl request on port 80 followed by opening a browser to the docker host on port 80.